### PR TITLE
escape auto interpolation of vue-press

### DIFF
--- a/Framework/framework-en.md
+++ b/Framework/framework-en.md
@@ -89,7 +89,9 @@ The above code simply implements how to listen for the `set` and `get` events of
 </div>
 ```
 
+::: v-pre
 In the process of parsing the template code like above, when encountering `{{name}}`, add a publish/subscribe to the property `name` 
+:::
 
 ```js
 // decouple by Dep

--- a/Framework/framework-zh.md
+++ b/Framework/framework-zh.md
@@ -85,8 +85,9 @@ function defineReactive(obj, key, val) {
     {{name}}
 </div>
 ```
-
+::: v-pre
 在解析如上模板代码时，遇到 `{{name}}` 就会给属性 `name` 添加发布订阅。
+:::
 
 ```js
 // 通过 Dep 解耦


### PR DESCRIPTION
Templating will be auto conversion by vue-press. as you can see [here](https://vuepress.vuejs.org/guide/using-vue.html#browser-api-access-restrictions)

sorry i made a mistake in the previous pr
here is the result of this commit

* before
![before](https://user-images.githubusercontent.com/20502467/42795286-0783164e-89b6-11e8-89b2-e636ec0bae16.png)

* after

![image](https://user-images.githubusercontent.com/20502467/42795263-ef9b34c6-89b5-11e8-9383-c237786fe728.png)
