### PR TITLE
Fixed minor typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 > A project to change the interview — Interview Map.
 
 
-The best job-hopping seasons, September and October, are coming（For Chinese, there is an idiom called "Golden September and Silver October”). Most people will be eager to prepare for and to persue better job opportunities. The interview will be their biggest challenge.
+The best job-hopping seasons, September and October, are coming（For Chinese, there is an idiom called "Golden September and Silver October”). Most people will be eager to prepare for and to pursue better job opportunities. The interview will be their biggest challenge.
 
 For the interview, the usual accumulation of learning is necessary, but the preparation before the interview is also crucial.
 
 A few months ago, I set up a small team. It took half a year to search for interview questions from the big company, filtering out nearly 100 knowledge points, writing the content and translating them all into English. Today, we finally release the first version and the total number of words has reached more than 100,000 at present. 
 
-We think that the blind memory of the interview questions is not very useful. Only when you are familiar with the various knowledge points and are capable of integrating them, can you get through the interviews. This interviewmap currently contains nearly a hundred high-frequency knowledge points, no matter the preparation before the interview or the study, we believe that it will help you. The current content includes JS, network, browser related, performance optimization, security, framework, Git, data structure, algorithm, etc. Whether it is basic or advanced learning or source code interpretation, you can get a satisfactory answer in this interviewmap, and we hope that the interviewmap can help you better prepare for the interview.
+We think that the blind memory of the interview questions is not very useful. Only when you are familiar with the various knowledge points and are capable of integrating them, can you get through the interviews. This InterviewMap currently contains nearly a hundred high-frequency knowledge points, no matter the preparation before the interview or the study, we believe that it will help you. The current content includes JS, network, browser related, performance optimization, security, framework, Git, data structure, algorithm, etc. Whether it is basic or advanced learning or source code interpretation, you can get a satisfactory answer in this InterviewMap, and we hope that the InterviewMap can help you better prepare for the interview.
 
 The contents of the repository will update continuously, and more content will be added into the repository later, such as system design, the blockchain, operating and support, backend, etc. Of course, these are not my strengths, and I will invite friends who have good experience in this area to write content.
 


### PR DESCRIPTION
Change "persue" to "pursue"

Change "intervewmap" to "InterviewMap", it is supposed to be the project name, without capitals it would just be a mis-spelled word.